### PR TITLE
Towards v0.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,17 @@ plugins {
 
 base {
     group = "io.github.qupath"
-    version = "0.1.1-SNAPSHOT"
+    version = "0.2.0-SNAPSHOT"
     description = "Gradle plugin for developing QuPath extensions"
 }
 
 java {
     withSourcesJar()
     withJavadocJar()
+
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
 }
 
 repositories {

--- a/src/main/java/qupath/gradle/QuPathGradleSettings.java
+++ b/src/main/java/qupath/gradle/QuPathGradleSettings.java
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -71,7 +72,27 @@ public class QuPathGradleSettings implements Plugin<Settings> {
         catalogBuilder.create(catalogName, catalog -> {
             logger.info("Creating QuPath version catalog named \"{}\"", catalogName);
             catalog.from("io.github.qupath:qupath-catalog:" + qupathVersion);
+
+            if (addQuPathToCatalog(qupathVersion)) {
+                catalog.version("qupath", qupathVersion);
+                catalog.library("qupath.gui.fx", "io.github.qupath", "qupath-gui-fx").versionRef("qupath");
+                catalog.library("qupath.core", "io.github.qupath", "qupath-core").versionRef("qupath");
+                catalog.library("qupath.core.processing", "io.github.qupath", "qupath-core-processing").versionRef("qupath");
+                catalog.bundle("qupath", List.of("qupath.gui.fx", "qupath.core", "qupath.core.processing"));
+                }
         });
+    }
+
+    /**
+     * Before QuPath v0.6.0, the versions for the QuPath jars weren't included in the catalog -
+     * so we need to add these here
+     * @param qupathVersion the QuPath version, e.g. "0.5.2"
+     * @return
+     */
+    private static boolean addQuPathToCatalog(String qupathVersion) {
+        return qupathVersion.startsWith("0.4") ||
+                qupathVersion.startsWith("0.5") ||
+                Set.of("0.6.0-rc1", "0.6.0-rc2", "0.6.0-rc3").contains(qupathVersion);
     }
 
 }

--- a/src/main/kotlin/qupath-conventions.gradle.kts
+++ b/src/main/kotlin/qupath-conventions.gradle.kts
@@ -34,13 +34,18 @@ afterEvaluate {
 
     tasks.jar {
         manifest {
-            attributes(
-                mapOf(
-                    "Implementation-Title" to qupathExtension.name.get(),
-                    "Implementation-Version" to qupathExtension.version.get(),
-                    "Automatic-Module-Name" to qupathExtension.automaticModule.get()
-                )
+            // Core manifest attributes
+            val attributeMap = mutableMapOf(
+                "Implementation-Title" to qupathExtension.name.get(),
+                "Implementation-Version" to qupathExtension.version.get(),
+                "Automatic-Module-Name" to qupathExtension.automaticModule.get()
             )
+            // Store QuPath version if we can find it
+            var qupathVersion = findRequiredVersionInCatalog("qupath")
+            if (!qupathVersion.isNullOrBlank())
+                attributeMap["QuPath-Version"] = qupathVersion
+
+            attributes(attributeMap)
         }
     }
 }
@@ -142,7 +147,7 @@ javafx {
  */
 tasks.javadoc {
     val strictJavadoc = providers.gradleProperty("strictJavadoc").getOrElse("false")
-    if ("true" == strictJavadoc) {
+    if ("true" != strictJavadoc) {
         (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:none", "-quiet")
     }
 }


### PR DESCRIPTION
- Build with Java 11 (for compatibility with older QuPath dependencies)
- Add QuPath version & libraries to older catalogs, to help build extensions for QuPath v0.4.x and v0.5.x
- Add 'QuPath-Version' entry to the jar manifest
- Quiet javadocs by default