### PR TITLE
Support toolchain gradle or system property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 base {
     group = "io.github.qupath"
-    version = "0.2.0"
+    version = "0.2.1-SNAPSHOT"
     description = "Gradle plugin for developing QuPath extensions"
 }
 

--- a/src/main/kotlin/qupath-conventions.gradle.kts
+++ b/src/main/kotlin/qupath-conventions.gradle.kts
@@ -108,7 +108,8 @@ tasks.register<Copy>("copyDependencies") {
  * Ensure we include sources and javadocs when building.
  */
 java {
-    val jdkVersion = findRequiredVersionInCatalog("jdk")
+    // Java typically added
+    var jdkVersion = findToolchainVersion()
     if (!jdkVersion.isNullOrEmpty()) {
         toolchain {
             languageVersion = JavaLanguageVersion.of(jdkVersion)
@@ -116,6 +117,26 @@ java {
     }
     withSourcesJar()
     withJavadocJar()
+}
+
+/**
+ * Work out which Java version to use for the build
+ */
+fun findToolchainVersion(): String? {
+    // Try Gradle property
+    var toolchainVersion = providers.gradleProperty("toolchain").orNull
+    if (!toolchainVersion.isNullOrEmpty()) {
+        println("Using toolchain version $toolchainVersion from gradle property")
+        return toolchainVersion
+    }
+    // Try System property
+    toolchainVersion = System.getProperty("toolchain")
+    if (!toolchainVersion.isNullOrEmpty()) {
+        println("Using toolchain version $toolchainVersion from system property")
+        return toolchainVersion
+    }
+    // Default to version catalog
+    return findRequiredVersionInCatalog("jdk")
 }
 
 /*


### PR DESCRIPTION
This is needed to use includeBuild with QuPath when the QuPath Java version is higher than the extension Java version.